### PR TITLE
Problem: War Protocol doesn't use $ for separating instructions

### DIFF
--- a/src/main/groovy/com/github/lburgazzoli/gradle/plugin/karaf/mvn/MvnDependencyResolver.groovy
+++ b/src/main/groovy/com/github/lburgazzoli/gradle/plugin/karaf/mvn/MvnDependencyResolver.groovy
@@ -39,7 +39,11 @@ class MvnDependencyResolver extends DependencyResolver {
                     result, entry -> result << "${entry.key}=${entry.value}"
                 }.join('&')
 
-                url = "${url}\$${res}"
+                if (dependency.isWar()) {
+                    url = "${url}?${res}"
+                } else {
+                    url = "${url}\$${res}"
+                }
             }
         } else if (!dependency.isOSGi() && !dependency.isWar()) {
             // if the resolved file does not have "proper" OSGi headers we

--- a/src/test/groovy/com/github/lburgazzoli/gradle/plugin/karaf/features/KarafWarFeaturesTest.groovy
+++ b/src/test/groovy/com/github/lburgazzoli/gradle/plugin/karaf/features/KarafWarFeaturesTest.groovy
@@ -66,7 +66,7 @@ class KarafWarFeaturesTest extends KarafTestSupport {
             featuresXml.feature.@version == '1.2.3'
 
             featuresXml.feature.bundle.'**'.findAll {
-                it.text().contains('war:mvn:org.apache.activemq/activemq-web-console/5.13.2/war')
+                it.text().contains('war:mvn:org.apache.activemq/activemq-web-console/5.13.2/war?Webapp-Context=activemq-web-console')
             }.size() == 1
     }
 }


### PR DESCRIPTION
See: https://ops4j1.jira.com/wiki/display/paxurl/War+Protocol

Instead of

```
war:mvn:org.apache.wicket/wicket-examples/1.3.0/war$Webapp-Context=wicket
```

it uses a question mark:

```
war:mvn:org.apache.wicket/wicket-examples/1.3.0/war?Webapp-Context=wicket
```

However, the plugin doesn't follow this behaviour.

Solution: when the bundle is detected to be a WAR, instructions should be
separated with a question mark.