### PR TITLE
Issue #65 - Fix KAR generation for jars with classifiers.

### DIFF
--- a/src/main/groovy/com/github/lburgazzoli/gradle/plugin/karaf/kar/KarafKarTask.groovy
+++ b/src/main/groovy/com/github/lburgazzoli/gradle/plugin/karaf/kar/KarafKarTask.groovy
@@ -62,7 +62,9 @@ class KarafKarTask extends Jar implements KarafTaskTrait  {
                     asKarPath(
                         root,
                         "${it.group.replaceAll("\\.", "/")}/${it.name}/${it.version}",
-                        "${it.name}-${it.version}.${it.type}"
+                        it.hasClassifier()
+                            ? "${it.name}-${it.version}-${it.classifier}.${it.type}"
+                            : "${it.name}-${it.version}.${it.type}"
                     )
                 )
             }


### PR DESCRIPTION
Account for classifiers copying jars into exploded directory to be zipped into the KAR.