### PR TITLE
Conventions / Provisioning

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -17,6 +17,12 @@ Automatically generate Karaf feature file in /build/karaf/features
 gradle generateFeatures
 ----
 
+Automatically generate Karaf repo (system directory) in /build/karaf/repo
+[source,groovy]
+----
+gradle generateRepo
+----
+
 Automatically generate Karaf kar file in /build/karaf/kar
 [source,groovy]
 ----
@@ -26,7 +32,7 @@ gradle generateKar
 
 == Description
 
-The *gradle-karaf-plugin* is designed to automate the process of creating Apache Karaf *feature* and *kar* files.
+The *gradle-karaf-plugin* is designed to automate the process of creating Apache Karaf *feature*, *repo*, and *kar* files.
 
 This plugin generates the desired karaf files by utilizing the native gradle configurations mechanism. As gradle automatically determines all direct and transitive dependencies, a complete list of dependencies is provided to the plugin for a given set of configurations.
 
@@ -202,8 +208,9 @@ karaf {
         }
     }
 
-    // Enable generation of an OSGi bundles repository, laid out as a Maven 2 repository based on the features defined above. 
-    // This can be used to provision the 'system' directory of a custom Karaf distribution.
+    // Enable generation of an OSGi bundles repository, laid out as a Maven 2 repository based on
+    // the features defined above. This can be used to provision the 'system' directory of a
+    // custom Karaf distribution.
     // To generate repo use generateRepo, assemble or install
     repo {
     }

--- a/README.adoc
+++ b/README.adoc
@@ -202,6 +202,12 @@ karaf {
         }
     }
 
+    // Enable generation of an OSGi bundles repository, laid out as a Maven 2 repository based on the features defined above. 
+    // This can be used to provision the 'system' directory of a custom Karaf distribution.
+    // To generate repo use generateRepo, assemble or install
+    repo {
+    }
+
     // Enable generation of Karaf Archive KAR based on features defined above.
     // To generate kar either use generateKar, assemble or install
     kar {

--- a/src/main/groovy/com/github/lburgazzoli/gradle/plugin/karaf/KarafPlugin.groovy
+++ b/src/main/groovy/com/github/lburgazzoli/gradle/plugin/karaf/KarafPlugin.groovy
@@ -48,7 +48,7 @@ class KarafPlugin implements Plugin<Project> {
             description = KarafFeaturesTask.DESCRIPTION
         }
         
-        // Karaf Repo (provision system directory)
+        // Karaf Repo
         def repo = project.task( KarafRepoTask.NAME , type: KarafRepoTask ) {
             group       = KarafRepoTask.GROUP
             description = KarafRepoTask.DESCRIPTION
@@ -62,7 +62,7 @@ class KarafPlugin implements Plugin<Project> {
             description = KarafKarTask.DESCRIPTION
         }
 
-        kar.dependsOn feat
+        kar.dependsOn repo
 
         def war = project.tasks.find { it.name == WarPlugin.WAR_TASK_NAME }
         def jar = project.tasks.find { it.name == JavaPlugin.JAR_TASK_NAME }
@@ -107,7 +107,7 @@ class KarafPlugin implements Plugin<Project> {
             }
             
             if (ext.hasRepo()) {
-                // if there is an output file, add that as an output
+                // if there is an output directory, add that as an output
                 if (ext.repo.outputDir != null) {
                     repo.outputs.dir(ext.repo.outputDir)
                 }

--- a/src/main/groovy/com/github/lburgazzoli/gradle/plugin/karaf/KarafPlugin.groovy
+++ b/src/main/groovy/com/github/lburgazzoli/gradle/plugin/karaf/KarafPlugin.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.WarPlugin
 
 import com.github.lburgazzoli.gradle.plugin.karaf.features.KarafFeaturesTask
+import com.github.lburgazzoli.gradle.plugin.karaf.repo.KarafRepoTask
 import com.github.lburgazzoli.gradle.plugin.karaf.kar.KarafKarTask
 /**
  * @author lburgazzoli
@@ -46,6 +47,14 @@ class KarafPlugin implements Plugin<Project> {
             group       = KarafFeaturesTask.GROUP
             description = KarafFeaturesTask.DESCRIPTION
         }
+        
+        // Karaf Repo (provision system directory)
+        def repo = project.task( KarafRepoTask.NAME , type: KarafRepoTask ) {
+            group       = KarafRepoTask.GROUP
+            description = KarafRepoTask.DESCRIPTION
+        }
+        
+        repo.dependsOn feat
 
         // Karaf KAR
         def kar = project.task( KarafKarTask.NAME , type: KarafKarTask) {
@@ -96,10 +105,16 @@ class KarafPlugin implements Plugin<Project> {
                     feat.outputs.file(ext.features.outputFile)
                 }
             }
-
-            project.artifacts.add(ARTIFACTS_CONFIGURATION_NAME, ext.features.outputFile) {
-                classifier = 'features'
+            
+            if (ext.hasRepo()) {
+                // if there is an output file, add that as an output
+                if (ext.repo.outputDir != null) {
+                    repo.outputs.dir(ext.repo.outputDir)
+                }
             }
+
+            project.artifacts.add(ARTIFACTS_CONFIGURATION_NAME, ext.features.outputFile)
+            project.artifacts.add(ARTIFACTS_CONFIGURATION_NAME, ext.repo.outputDir)
             project.artifacts.add(ARTIFACTS_CONFIGURATION_NAME, kar)
         }
     }

--- a/src/main/groovy/com/github/lburgazzoli/gradle/plugin/karaf/KarafPluginExtension.groovy
+++ b/src/main/groovy/com/github/lburgazzoli/gradle/plugin/karaf/KarafPluginExtension.groovy
@@ -19,6 +19,7 @@ import org.gradle.api.Project
 import org.gradle.util.ConfigureUtil
 
 import com.github.lburgazzoli.gradle.plugin.karaf.features.KarafFeaturesExtension
+import com.github.lburgazzoli.gradle.plugin.karaf.repo.KarafRepoExtension
 import com.github.lburgazzoli.gradle.plugin.karaf.kar.KarafKarExtension
 
 /**
@@ -29,11 +30,13 @@ class KarafPluginExtension {
 
     private final Project project
     private KarafFeaturesExtension features
+    private KarafRepoExtension repo
     private KarafKarExtension kar
 
     KarafPluginExtension(Project project) {
         this.project = project
         this.features = null
+        this.repo = null
         this.kar = null
     }
 
@@ -56,7 +59,30 @@ class KarafPluginExtension {
     boolean hasFeatures() {
         return !getFeatures().featureDescriptors.empty
     }
+    
+    // *************************************************************************
+    // Repo
+    // *************************************************************************
 
+    def repo(Closure closure)  {
+        getRepo()
+      
+        repo.enabled = true
+        repo = ConfigureUtil.configure(closure, repo)
+    }
+    
+    KarafRepoExtension getRepo() {
+        if (!this.repo) {
+          this.repo = new KarafRepoExtension(project)
+        }
+        
+        return this.repo
+    }
+    
+    boolean hasRepo() {
+        return getRepo().enabled
+    }
+  
     // *************************************************************************
     // Kar
     // *************************************************************************

--- a/src/main/groovy/com/github/lburgazzoli/gradle/plugin/karaf/features/KarafFeaturesExtension.groovy
+++ b/src/main/groovy/com/github/lburgazzoli/gradle/plugin/karaf/features/KarafFeaturesExtension.groovy
@@ -54,7 +54,7 @@ class KarafFeaturesExtension {
 
         this.outputFile = new File(
             "${project.buildDir}/karaf/features",
-            "${name}-${version}.xml"
+            "${name}-${version}-features.xml"
         )
     }
 

--- a/src/main/groovy/com/github/lburgazzoli/gradle/plugin/karaf/features/KarafFeaturesTask.groovy
+++ b/src/main/groovy/com/github/lburgazzoli/gradle/plugin/karaf/features/KarafFeaturesTask.groovy
@@ -61,7 +61,7 @@ class KarafFeaturesTask extends DefaultTask implements KarafTaskTrait {
         def resolver = karaf.resolver
 
         builder.mkp.xmlDeclaration(version: "1.0", encoding: "UTF-8", standalone: "yes")
-        builder.features(xmlns:FEATURES_XMLNS_PREFIX + karaf.xsdVersion, name: karaf.name) {
+        builder.features(xmlns:FEATURES_XMLNS_PREFIX + karaf.xsdVersion, name: karaf.name + '-' + karaf.version) {
             karaf.repositories.each {
                 builder.repository( it )
             }

--- a/src/main/groovy/com/github/lburgazzoli/gradle/plugin/karaf/kar/KarafKarExtension.groovy
+++ b/src/main/groovy/com/github/lburgazzoli/gradle/plugin/karaf/kar/KarafKarExtension.groovy
@@ -31,19 +31,11 @@ class KarafKarExtension {
     @OutputDirectory
     File outputDir
 
-    @OutputDirectory
-    File explodedDir
-
     KarafKarExtension(Project project) {
         this.project = project
         this.enabled = false
         this.outputDir = new File("${project.buildDir}/karaf/kar")
-        this.explodedDir = new File("${project.buildDir}/karaf/kar/exploded")
         this.archiveName = null
-    }
-
-    Path getExplodedPath() {
-        return explodedDir.toPath()
     }
 
     Path getOutputPath() {

--- a/src/main/groovy/com/github/lburgazzoli/gradle/plugin/karaf/kar/KarafKarTask.groovy
+++ b/src/main/groovy/com/github/lburgazzoli/gradle/plugin/karaf/kar/KarafKarTask.groovy
@@ -46,54 +46,9 @@ class KarafKarTask extends Jar implements KarafTaskTrait  {
         }
 
         def features = karaf.features
+        def repo = karaf.repo
         def kar = karaf.kar
-        def resolver = features.resolver
-        def root = kar.explodedPath
-
-        root.deleteDir()
-        Files.createDirectories(root)
-
-        features.featureDescriptors.each { feature ->
-            resolver.resolve(feature).each {
-                copy(
-                    it.file,
-                    asKarPath(
-                        root,
-                        "${it.group.replaceAll("\\.", "/")}/${it.name}/${it.version}",
-                        it.hasClassifier() && it.classifier
-                            ? "${it.name}-${it.version}-${it.classifier}.${it.type}"
-                            : "${it.name}-${it.version}.${it.type}"
-                    )
-                )
-            }
-
-            feature.configFiles.each {
-                if (it.filename && it.uri && it.file) {
-                    def dep = MvnProtocolParser.parse(it.uri)
-                    if (dep) {
-                        copy(
-                            it.file,
-                            asKarPath(
-                                root,
-                                "${dep.group.replaceAll("\\.", "/")}/${dep.name}/${dep.version}",
-                                dep.hasClassifier()
-                                    ? "${dep.name}-${dep.version}-${dep.classifier}.${dep.type}"
-                                    : "${dep.name}-${dep.version}.${dep.type}"
-                            )
-                        )
-                    }
-                }
-            }
-        }
-
-        copy(
-            features.outputPath,
-            asKarPath(
-                root,
-                "${features.group.replaceAll("\\.", "/")}/${features.name}/${features.version}",
-                "${features.name}-${features.version}-features.xml"
-            )
-        )
+        Files.createDirectories(kar.outputPath)
 
         archiveAppendix.set(null)
         archiveClassifier.set(null)
@@ -107,40 +62,9 @@ class KarafKarTask extends Jar implements KarafTaskTrait  {
             archiveBaseName.set(kar.archiveName)
         }
 
-        from(kar.explodedDir)
+        from(repo.outputDir)
+        into('repository')
 
         super.copy()
-    }
-
-
-    def copy(File source, Path destination) {
-        if (source && destination) {
-            copy(source.toPath(), destination)
-        }
-    }
-
-    def copy(File source, File destination) {
-        if (source && destination) {
-            copy(source.toPath(), destination.toPath())
-        }
-    }
-
-    def copy(Path source, Path destination) {
-        if (source) {
-            if (!Files.exists(destination.parent)) {
-                Files.createDirectories(destination.parent)
-            }
-
-            Files.copy(
-                source,
-                destination,
-                StandardCopyOption.REPLACE_EXISTING,
-                StandardCopyOption.COPY_ATTRIBUTES
-            )
-        }
-    }
-
-    def asKarPath(Path root, String path, String name) {
-        return root.resolve("repository").resolve(path).resolve(name)
     }
 }

--- a/src/main/groovy/com/github/lburgazzoli/gradle/plugin/karaf/kar/KarafKarTask.groovy
+++ b/src/main/groovy/com/github/lburgazzoli/gradle/plugin/karaf/kar/KarafKarTask.groovy
@@ -91,7 +91,7 @@ class KarafKarTask extends Jar implements KarafTaskTrait  {
             asKarPath(
                 root,
                 "${features.group.replaceAll("\\.", "/")}/${features.name}/${features.version}",
-                "${features.name}-${features.version}.xml"
+                "${features.name}-${features.version}-features.xml"
             )
         )
 

--- a/src/main/groovy/com/github/lburgazzoli/gradle/plugin/karaf/repo/KarafRepoExtension.groovy
+++ b/src/main/groovy/com/github/lburgazzoli/gradle/plugin/karaf/repo/KarafRepoExtension.groovy
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2016, Luca Burgazzoli and contributors as indicated by the @author tags
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.lburgazzoli.gradle.plugin.karaf.repo
+
+import java.nio.file.Path
+import org.gradle.api.Project
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.OutputFile
+
+/**
+ * @author realPyR3X
+ */
+class KarafRepoExtension {
+    private final Project project
+    boolean enabled;
+
+    @OutputDirectory
+    File outputDir
+
+    KarafRepoExtension(Project project) {
+        this.project = project
+        this.enabled = false
+        this.outputDir = new File("${project.buildDir}/karaf/repository")
+    }
+
+    Path getOutputPath() {
+        return outputDir.toPath()
+    }
+}

--- a/src/main/groovy/com/github/lburgazzoli/gradle/plugin/karaf/repo/KarafRepoExtension.groovy
+++ b/src/main/groovy/com/github/lburgazzoli/gradle/plugin/karaf/repo/KarafRepoExtension.groovy
@@ -34,7 +34,7 @@ class KarafRepoExtension {
     KarafRepoExtension(Project project) {
         this.project = project
         this.enabled = false
-        this.outputDir = new File("${project.buildDir}/karaf/repository")
+        this.outputDir = new File("${project.buildDir}/karaf/repo")
     }
 
     Path getOutputPath() {

--- a/src/main/groovy/com/github/lburgazzoli/gradle/plugin/karaf/repo/KarafRepoTask.groovy
+++ b/src/main/groovy/com/github/lburgazzoli/gradle/plugin/karaf/repo/KarafRepoTask.groovy
@@ -41,7 +41,7 @@ class KarafRepoTask extends DefaultTask implements KarafTaskTrait  {
     @TaskAction
     void run() {
         def karaf = getKaraf()
-        if (!karaf.hasRepo()) {
+        if (!karaf.hasRepo() && !karaf.hasKar()) {
             return;
         }
 

--- a/src/main/groovy/com/github/lburgazzoli/gradle/plugin/karaf/repo/KarafRepoTask.groovy
+++ b/src/main/groovy/com/github/lburgazzoli/gradle/plugin/karaf/repo/KarafRepoTask.groovy
@@ -1,0 +1,129 @@
+/**
+ * Copyright 2016, Luca Burgazzoli and contributors as indicated by the @author tags
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.lburgazzoli.gradle.plugin.karaf.repo
+
+import com.github.lburgazzoli.gradle.plugin.karaf.KarafTaskTrait
+import com.github.lburgazzoli.gradle.plugin.karaf.mvn.MvnProtocolParser
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+
+/**
+ * @author realPyR3X
+ */
+class KarafRepoTask extends DefaultTask implements KarafTaskTrait  {
+    public static final String GROUP = 'karaf'
+    public static final String NAME = 'generateRepo'
+    public static final String DESCRIPTION = 'Generates Karaf Repo Directory'
+
+    KarafRepoTask() {
+        outputs.upToDateWhen {
+            false
+        }
+    }
+
+    @TaskAction
+    void run() {
+        def karaf = getKaraf()
+        if (!karaf.hasRepo()) {
+            return;
+        }
+
+        def features = karaf.features
+        def repo = karaf.repo
+        def resolver = features.resolver
+        def root = repo.outputPath
+
+        root.deleteDir()
+        Files.createDirectories(root)
+
+        features.featureDescriptors.each { feature ->
+            resolver.resolve(feature).each {
+                copy(
+                    it.file,
+                    asRepoPath(
+                        root,
+                        "${it.group.replaceAll("\\.", "/")}/${it.name}/${it.version}",
+                        it.hasClassifier() && it.classifier
+                            ? "${it.name}-${it.version}-${it.classifier}.${it.type}"
+                            : "${it.name}-${it.version}.${it.type}"
+                    )
+                )
+            }
+
+            feature.configFiles.each {
+                if (it.filename && it.uri && it.file) {
+                    def dep = MvnProtocolParser.parse(it.uri)
+                    if (dep) {
+                        copy(
+                            it.file,
+                            asRepoPath(
+                                root,
+                                "${dep.group.replaceAll("\\.", "/")}/${dep.name}/${dep.version}",
+                                dep.hasClassifier()
+                                    ? "${dep.name}-${dep.version}-${dep.classifier}.${dep.type}"
+                                    : "${dep.name}-${dep.version}.${dep.type}"
+                            )
+                        )
+                    }
+                }
+            }
+        }
+
+        copy(
+            features.outputPath,
+            asRepoPath(
+                root,
+                "${features.group.replaceAll("\\.", "/")}/${features.name}/${features.version}",
+                "${features.name}-${features.version}-features.xml"
+            )
+        )
+    }
+
+    def copy(File source, Path destination) {
+        if (source && destination) {
+            copy(source.toPath(), destination)
+        }
+    }
+
+    def copy(File source, File destination) {
+        if (source && destination) {
+            copy(source.toPath(), destination.toPath())
+        }
+    }
+
+    def copy(Path source, Path destination) {
+        if (source) {
+            if (!Files.exists(destination.parent)) {
+                Files.createDirectories(destination.parent)
+            }
+
+            Files.copy(
+                source,
+                destination,
+                StandardCopyOption.REPLACE_EXISTING,
+                StandardCopyOption.COPY_ATTRIBUTES
+            )
+        }
+    }
+
+    def asRepoPath(Path root, String path, String name) {
+        return root.resolve(path).resolve(name)
+    }
+}

--- a/src/test/groovy/com/github/lburgazzoli/gradle/plugin/karaf/KarafTestSupport.groovy
+++ b/src/test/groovy/com/github/lburgazzoli/gradle/plugin/karaf/KarafTestSupport.groovy
@@ -17,6 +17,7 @@
 package com.github.lburgazzoli.gradle.plugin.karaf
 
 import com.github.lburgazzoli.gradle.plugin.karaf.features.KarafFeaturesTask
+import com.github.lburgazzoli.gradle.plugin.karaf.repo.KarafRepoTask
 import com.github.lburgazzoli.gradle.plugin.karaf.kar.KarafKarTask
 import groovy.util.slurpersupport.GPathResult
 import org.gradle.api.Project
@@ -35,6 +36,10 @@ class KarafTestSupport extends Specification {
 
     KarafFeaturesTask  getKarafFeaturesTasks(Project project) {
         project.tasks.getByName(KarafFeaturesTask.NAME)
+    }
+    
+    KarafRepoTask  getKarafRepoTasks(Project project) {
+        project.tasks.getByName(KarafRepoTask.NAME)
     }
 
     KarafKarTask getKarafKarTasks(Project project) {

--- a/src/test/groovy/com/github/lburgazzoli/gradle/plugin/karaf/features/KarafFeaturesTest.groovy
+++ b/src/test/groovy/com/github/lburgazzoli/gradle/plugin/karaf/features/KarafFeaturesTest.groovy
@@ -480,7 +480,7 @@ class KarafFeaturesTest extends KarafTestSupport {
             }.size() == 1
     }
 
-    def 'Single Project Wit Wrap'() {
+    def 'Single Project With Wrap'() {
         given:
             configureProject(project) {
                 dependencies {

--- a/src/test/groovy/com/github/lburgazzoli/gradle/plugin/karaf/features/KarafWarFeaturesTest.groovy
+++ b/src/test/groovy/com/github/lburgazzoli/gradle/plugin/karaf/features/KarafWarFeaturesTest.groovy
@@ -88,13 +88,14 @@ class KarafWarFeaturesTest extends KarafTestSupport {
         given:
             configureProject(project) {
                 apply plugin: 'war'
-                apply plugin: 'osgi'
 
                 war {
-                    manifest = osgiManifest {
-                        instruction 'Web-ContextPath', '/context-path'
-                        instruction 'Webapp-Context', '/context-path'
-                        instruction 'Bundle-ClassPath', '.;/WEB-INF/classes'
+                    manifest {
+                        attributes(
+                            'Web-ContextPath': '/context-path',
+                            'Webapp-Context': '/context-path',
+                            'Bundle-ClassPath': '.;/WEB-INF/classes'
+                        )
                     }
                 }
             }

--- a/src/test/groovy/com/github/lburgazzoli/gradle/plugin/karaf/kar/KarafKarTest.groovy
+++ b/src/test/groovy/com/github/lburgazzoli/gradle/plugin/karaf/kar/KarafKarTest.groovy
@@ -51,6 +51,7 @@ class KarafKarTest extends KarafTestSupport {
 
             def karaf = getKarafExtension(project)
             def features = getKarafFeaturesTasks(project)
+            def repo = getKarafRepoTasks(project)
             def kar = getKarafKarTasks(project)
         when:
             karaf.features {
@@ -63,6 +64,7 @@ class KarafKarTest extends KarafTestSupport {
             }
         then:
             features.run()
+            repo.run()
             kar.copy()
 
             def baseName = kar.archiveBaseName.get()
@@ -73,7 +75,7 @@ class KarafKarTest extends KarafTestSupport {
 
             def archive = kar.archiveFile.get().asFile
             def zf = new java.util.zip.ZipFile(archive)
-            null != zf.getEntry("repository/com/lburgazzoli/github/${project.name}/${project.version}/${project.name}-${project.version}.xml")
+            null != zf.getEntry("repository/com/lburgazzoli/github/${project.name}/${project.version}/${project.name}-${project.version}-features.xml")
             null != zf.getEntry("repository/commons-lang/commons-lang/2.6/commons-lang-2.6.jar")
     }
 }


### PR DESCRIPTION
1.) More closely follow the naming conventions of karaf feature repositories and features
2.) Add task to generate repository useful for provisioning a custom distribution without using a kar