### PR TITLE
Property karaf requires @Internal annotation for gradle 7+

### DIFF
--- a/src/main/groovy/com/github/lburgazzoli/gradle/plugin/karaf/KarafTaskTrait.groovy
+++ b/src/main/groovy/com/github/lburgazzoli/gradle/plugin/karaf/KarafTaskTrait.groovy
@@ -15,6 +15,7 @@
  */
 package com.github.lburgazzoli.gradle.plugin.karaf
 
+import org.gradle.api.tasks.Internal
 import org.gradle.util.ConfigureUtil
 
 /**
@@ -34,6 +35,7 @@ trait KarafTaskTrait {
         this.pluginExtension = pluginExtension
     }
 
+    @Internal
     KarafPluginExtension getKaraf() {
         // Don't keep looking it up...
         if (this.pluginExtension == null) {


### PR DESCRIPTION
When building a gradle 7 project using plugin v0.5.2 the following error is thrown:

```
A problem was found with the configuration of task ':generateFeatures' (type 'KarafFeaturesTask').
  - In plugin 'com.github.lburgazzoli.karaf' type 'com.github.lburgazzoli.gradle.plugin.karaf.features.KarafFeaturesTask' property 'karaf' is missing an input or output annotation.
```
  
Adding @Internal to the karaf property will fix it.

There is already a PR open since july 2021 containing the same fix, but for some reason it failed to build and wasn't merged. This PR is a **minimal** fix  and expected to merge without problems. Hope you can find some to to do it.